### PR TITLE
Missing Javascript global variables

### DIFF
--- a/bytecomp/px.ml
+++ b/bytecomp/px.ml
@@ -1590,6 +1590,8 @@ include
           "location";
           "window";
           "document";
+			 "top";
+			 "content";
           "eval";
           "navigator";
           "self";


### PR DESCRIPTION
top and content are always available in a browser, this commit adds them to
the reserved keywords list.